### PR TITLE
fix: Resolve simulator thread leak leading to resource exhaustion

### DIFF
--- a/src/chemotaxis/sim/AgentWrapper.java
+++ b/src/chemotaxis/sim/AgentWrapper.java
@@ -32,6 +32,7 @@ public class AgentWrapper {
             Log.writeToVerboseLogFile("Exception for team " + this.agentName + "'s agent: " + e);
         }
 
+        timer.terminate();
         return move;
     }
     

--- a/src/chemotaxis/sim/Timer.java
+++ b/src/chemotaxis/sim/Timer.java
@@ -10,6 +10,12 @@ public class Timer extends Thread {
 	private Exception error = null;
 	private Object result = null;
 	private long startTime, endTime;
+	private boolean running;
+
+	public Timer() {
+		super();
+		this.running = true;
+	}
 
 	public <T> void callStart(Callable <T> task) {
 		if(!isAlive())
@@ -17,7 +23,7 @@ public class Timer extends Thread {
 		if(task == null)
 			throw new IllegalArgumentException();
 		this.task = task;
-		
+
 		synchronized(this) {
 			started = true;
 			this.startTime = System.currentTimeMillis();
@@ -28,7 +34,6 @@ public class Timer extends Thread {
 	public <T> T callWait(long timeout) throws Exception {
 		if(timeout < 0)
 			throw new IllegalArgumentException();
-		
 		synchronized(this) {
 			if(completed == false)
 				try {
@@ -52,6 +57,9 @@ public class Timer extends Thread {
 	public void run() {
 		while(true) {
 			synchronized(this) {
+				if (!this.running) {
+					return;
+				}
 				if(started == false)
 					try {
 						wait();
@@ -72,6 +80,12 @@ public class Timer extends Thread {
 				completed = true;
 				notify();
 			}
+		}
+	}
+
+	public void terminate() {
+		synchronized (this) {
+			this.running = false;
 		}
 	}
 	


### PR DESCRIPTION
Each instance of the AgentWrapper has its own thread (Timer). Since
the simulator creates a new AgentWrapper on each turn and does not
terminate the Timer thread, the simulator leaks a thread on each
turn.

For games with a large number of turns this results in resource
exhaustion when the number of threads exceeds the OS limit.

This commit makes AgentWrapper terminate its Timer thread before
`makeMove` returns. The existing code already restarts the thread when
the next `makeMove` needs it, so no other changes are necessary.

This is why some groups reported the simulator crashing during the last class.