### PR TITLE
fix: Resolve race condition in cleaning up AgentWrapper thread

### DIFF
--- a/src/chemotaxis/sim/AgentWrapper.java
+++ b/src/chemotaxis/sim/AgentWrapper.java
@@ -32,7 +32,6 @@ public class AgentWrapper {
             Log.writeToVerboseLogFile("Exception for team " + this.agentName + "'s agent: " + e);
         }
 
-        timer.terminate();
         return move;
     }
     
@@ -42,5 +41,9 @@ public class AgentWrapper {
 
     public String getAgentName() {
         return agentName;
+    }
+
+    public void terminateThread() {
+        this.timer.terminate();
     }
 }

--- a/src/chemotaxis/sim/Simulator.java
+++ b/src/chemotaxis/sim/Simulator.java
@@ -508,6 +508,7 @@ public class Simulator {
 						numReached ++;
 					}
 				}
+				agentWrapper.terminateThread();
 			
 			} catch (Exception e) {
 				Log.writeToLogFile("Unable to load or run agent: " + e.getMessage());


### PR DESCRIPTION
Turns out my last patch introduced a race condition:

- Make move finishes
- Flag to terminate timer thread is set to true
- `timer.isAlive()` runs and returns true because the thread hasn't actually terminated
- Now the thread terminates
- `timer.callStart()` throws an exception because the thread is now terminated

This patch moves the thread cleanup after all agents have moved and we no longer need the AgentWrapper object.